### PR TITLE
fix: the '--user N' option does not exist

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -103,12 +103,6 @@ parameters:
 			path: src/PageTypes/RssFeed.php
 
 		-
-			message: '#^Access to an undefined property Siteman\\Cms\\Resources\\PageResource\\Livewire\\PageTree\:\:\$pages\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Resources/PageResource/Livewire/PageTree.php
-
-		-
 			message: '#^Method Siteman\\Cms\\Torchlight\\BaseExtension\:\:getTheme\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1


### PR DESCRIPTION
Fixes the swallowed error
```
  The "--user 1" option does not exist.
```
which leads to no super-admin role being assigned to the first user.

If we need to stick to `Process::run` we should refactor the call to 
```
$result = Process::run([(new PhpExecutableFinder)->find(), 'artisan', 'shield:super-admin', '--user', $user->id]);
```
and verify the exit code.